### PR TITLE
Validate endpoint ownership for endpoint-group POST/PUT and add shared helper

### DIFF
--- a/lib/services/endpoint-groups-validation.ts
+++ b/lib/services/endpoint-groups-validation.ts
@@ -1,0 +1,20 @@
+import { getDb } from "@/lib/db"
+import { endpoints } from "@/lib/db/schema/endpoints"
+import { and, eq, inArray } from "drizzle-orm"
+
+type DbClient = Awaited<ReturnType<typeof getDb>>
+
+export async function validateUserEndpointAccess(
+  db: DbClient,
+  userId: string,
+  endpointIds: string[]
+): Promise<boolean> {
+  const validEndpoints = await db.query.endpoints.findMany({
+    where: and(
+      eq(endpoints.userId, userId),
+      inArray(endpoints.id, endpointIds)
+    )
+  })
+
+  return validEndpoints.length === endpointIds.length
+}


### PR DESCRIPTION
### Motivation

- Ensure `PUT /api/endpoint-groups/[id]` performs the same endpoint ownership checks as `POST` so clients cannot attach endpoints they don't own. 
- Centralize and reuse the endpoint ownership check to avoid duplicate logic and future omission.

### Description

- Add a shared validator `validateUserEndpointAccess` in `lib/services/endpoint-groups-validation.ts` that queries `endpoints` for `userId = session.user.id` and `id in endpointIds` and compares counts. 
- Use `validateUserEndpointAccess` in `POST /api/endpoint-groups` (now using `validatedData` from `safeParse`) to replace the previous inline query. 
- Add the same ownership check to `PUT /api/endpoint-groups/[id]` and only perform the update/delete/insert of relations after the check passes. 
- Update imports and wire the new helper into `app/api/endpoint-groups/route.ts` and `app/api/endpoint-groups/[id]/route.ts`.

### Testing

- Ran linting with `pnpm next lint --file app/api/endpoint-groups/route.ts --file app/api/endpoint-groups/[id]/route.ts --file lib/services/endpoint-groups-validation.ts`, which reported no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ca60640d0832e8bda6da99669181b)